### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-accessing-vault
-This guide walks you through the process of using http://projects.spring.io/spring-vault/[Spring Vault] to build an application that loads secrets from https://www.vaultproject.io/[HashiCorp Vault], a secrets management tool.
+This guide walks you through the process of using https://projects.spring.io/spring-vault/[Spring Vault] to build an application that loads secrets from https://www.vaultproject.io/[HashiCorp Vault], a secrets management tool.
 
 == What you'll build
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://projects.spring.io/spring-vault/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-vault/ ([https](https://projects.spring.io/spring-vault/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8200 with 1 occurrences