### PR TITLE
Update README.adoc to address typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ Launch another console window to store application configuration in Vault using 
 First, you need to set two environment variables to point the Vault CLI to the Vault endpoint and provide
 an authentication token.
 
-    $ export export VAULT_TOKEN="00000000-0000-0000-0000-000000000000"
+    $ export VAULT_TOKEN="00000000-0000-0000-0000-000000000000"
     $ export VAULT_ADDR="http://127.0.0.1:8200"
 
 Now you can store a configuration key-value pairs inside Vault:


### PR DESCRIPTION
Removing `export` typo